### PR TITLE
added "+" to regex allowed characters

### DIFF
--- a/util/validator.py
+++ b/util/validator.py
@@ -13,7 +13,7 @@ class ValidationState:
     def __init__(self, **entries): 
         self.__dict__.update(entries)
 
-valid_file_characters_re = re.compile(r"^[A-Za-z0-9.\-_/@]+$")
+valid_file_characters_re = re.compile(r"^[A-Za-z0-9.\-_/@\+]+$")
 
 class PullValidator(INIValidator, CodeValidator, VersionValidator, UpdateJSONValidator):
     """


### PR DESCRIPTION
Riot constantly uses "+" in your files e.g `riot+compiler.min.js`